### PR TITLE
New strategy for attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 *[M]: major change; [m]: minor change*
 
 * Lib:
+    - [M] **Attach objects in their original shape (not simplified), after removal of possible circular refs**
     - [m] Add `stdinLogger` tool (result from issue #11): use it to log via Storyboard the output of any command, e.g. `ls | node stdinLogger.js`
 
 ## 1.2.0 (Apr. 19, 2016)

--- a/package.coffee
+++ b/package.coffee
@@ -43,13 +43,7 @@ specs =
 
     compile: _runMultiple [
       "rm -rf lib"
-      "coffee --no-header -o lib -c src/storyboard.coffee"
-      "coffee --no-header -o lib -c src/noPlugins.coffee"
-      "coffee --no-header -o lib -c src/stdinLogger.coffee"
-      "coffee --no-header -o lib/gral -c src/gral"
-      "coffee --no-header -o lib/listeners -c src/listeners"
-      "coffee --no-header -o lib/vendor -c src/vendor"
-      "coffee --no-header -o lib/chromeExtension -c src/chromeExtension"
+      "coffee --no-header -o lib -c src"
       "babel -d lib src"
     ]
 
@@ -74,7 +68,10 @@ specs =
       "cp example/*.eot example/*.ttf example/*.woff* example/*.svg example/*.js #{HEROKU_CLIENT}/"
     ]
     buildExampleWatch:        "#{WEBPACK_EXAMPLE} --watch"
-    example:                  "coffee src/example/server.coffee"
+    example: _runMultiple [
+      "npm run compile"
+      "node lib/example/server"
+    ]
 
     # General
     build:                    _runMultiple [

--- a/package.coffee
+++ b/package.coffee
@@ -121,8 +121,8 @@ specs =
   # ## Storyboard library dependencies
   #-================================================================
   dependencies:
-    "timm": "0.6.0"
-    "chalk": "1.1.1"
+    "timm": "0.6.1"
+    "chalk": "1.1.3"
     "bluebird": "3.3.1"
     "express": "4.13.4"
     "socket.io": "1.4.5"
@@ -139,7 +139,7 @@ specs =
     #-----------------------------------------------------------------
     # ### Packaged in the Chrome extension
     #-----------------------------------------------------------------
-    "babel-polyfill":       "6.6.1"     # es6
+    "babel-polyfill":       "6.9.1"     # es6
 
     # React
     "react":                          "15.0.1"
@@ -185,7 +185,7 @@ specs =
     "babel-preset-stage-2": "6.5.0"
 
     # Webpack + loaders (+ related stuff)
-    "webpack": "1.12.13"
+    "webpack": "1.13.1"
     "babel-loader": "6.2.4"
     "coffee-loader": "0.7.2"
     "cjsx-loader": "2.1.0"

--- a/package.coffee
+++ b/package.coffee
@@ -50,6 +50,7 @@ specs =
       "coffee --no-header -o lib/listeners -c src/listeners"
       "coffee --no-header -o lib/vendor -c src/vendor"
       "coffee --no-header -o lib/chromeExtension -c src/chromeExtension"
+      "babel -d lib src"
     ]
 
     # Server logs app
@@ -180,10 +181,11 @@ specs =
     "coffee-script": "1.10.0"
 
     # Babel + plugins
-    "babel-core":           "6.6.5"     # es6
-    "babel-preset-es2015":  "6.6.0"     # for ES2015 (a.k.a. ES6)
-    "babel-preset-react":   "6.5.0"     # for React
-    "babel-preset-stage-2": "6.5.0"     # to replace the "stage" of support option in a Webpack config    
+    "babel-cli":            "6.9.0"
+    "babel-core":           "6.9.1"
+    "babel-preset-es2015":  "6.9.0"
+    "babel-preset-react":   "6.5.0"
+    "babel-preset-stage-2": "6.5.0"
 
     # Webpack + loaders (+ related stuff)
     "webpack": "1.12.13"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/guigrpa/storyboard.git"
   },
   "scripts": {
-    "compile": "rm -rf lib && coffee --no-header -o lib -c src/storyboard.coffee && coffee --no-header -o lib -c src/noPlugins.coffee && coffee --no-header -o lib -c src/stdinLogger.coffee && coffee --no-header -o lib/gral -c src/gral && coffee --no-header -o lib/listeners -c src/listeners && coffee --no-header -o lib/vendor -c src/vendor && coffee --no-header -o lib/chromeExtension -c src/chromeExtension",
+    "compile": "rm -rf lib && coffee --no-header -o lib -c src/storyboard.coffee && coffee --no-header -o lib -c src/noPlugins.coffee && coffee --no-header -o lib -c src/stdinLogger.coffee && coffee --no-header -o lib/gral -c src/gral && coffee --no-header -o lib/listeners -c src/listeners && coffee --no-header -o lib/vendor -c src/vendor && coffee --no-header -o lib/chromeExtension -c src/chromeExtension && babel -d lib src",
     "buildServerLogsApp": "cross-env NODE_ENV=production webpack --config src/serverLogsApp/webpackConfig.coffee --colors --progress -p",
     "buildServerLogsAppWatch": "webpack --config src/serverLogsApp/webpackConfig.coffee --colors --progress --watch",
     "buildExtension": "cross-env NODE_ENV=production webpack --config src/chromeExtension/webpackConfig.coffee --colors --progress -p",
@@ -55,10 +55,11 @@
     "timm": "0.6.0"
   },
   "devDependencies": {
-    "babel-core": "6.6.5",
+    "babel-cli": "6.9.0",
+    "babel-core": "6.9.1",
     "babel-loader": "6.2.4",
     "babel-polyfill": "6.6.1",
-    "babel-preset-es2015": "6.6.0",
+    "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-2": "6.5.0",
     "bestzip": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -45,20 +45,20 @@
   },
   "dependencies": {
     "bluebird": "3.3.1",
-    "chalk": "1.1.1",
+    "chalk": "1.1.3",
     "express": "4.13.4",
     "lodash": "4.5.0",
     "node-uuid": "1.4.7",
     "platform": "1.3.1",
     "socket.io": "1.4.5",
     "split": "1.0.0",
-    "timm": "0.6.0"
+    "timm": "0.6.1"
   },
   "devDependencies": {
     "babel-cli": "6.9.0",
     "babel-core": "6.9.1",
     "babel-loader": "6.2.4",
-    "babel-polyfill": "6.6.1",
+    "babel-polyfill": "6.9.1",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-2": "6.5.0",
@@ -101,7 +101,7 @@
     "style-loader": "0.13.0",
     "tinycolor2": "1.3.0",
     "uglifyjs": "2.4.10",
-    "webpack": "1.12.13",
+    "webpack": "1.13.1",
     "xxl": "0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/guigrpa/storyboard.git"
   },
   "scripts": {
-    "compile": "rm -rf lib && coffee --no-header -o lib -c src/storyboard.coffee && coffee --no-header -o lib -c src/noPlugins.coffee && coffee --no-header -o lib -c src/stdinLogger.coffee && coffee --no-header -o lib/gral -c src/gral && coffee --no-header -o lib/listeners -c src/listeners && coffee --no-header -o lib/vendor -c src/vendor && coffee --no-header -o lib/chromeExtension -c src/chromeExtension && babel -d lib src",
+    "compile": "rm -rf lib && coffee --no-header -o lib -c src && babel -d lib src",
     "buildServerLogsApp": "cross-env NODE_ENV=production webpack --config src/serverLogsApp/webpackConfig.coffee --colors --progress -p",
     "buildServerLogsAppWatch": "webpack --config src/serverLogsApp/webpackConfig.coffee --colors --progress --watch",
     "buildExtension": "cross-env NODE_ENV=production webpack --config src/chromeExtension/webpackConfig.coffee --colors --progress -p",
@@ -30,7 +30,7 @@
     "buildExample": "webpack --config src/example/webpackConfig.coffee --colors --progress",
     "buildExampleHeroku": "rm -f example/heroku/client/*.eot example/heroku/client/*.ttf example/heroku/client/*.woff* example/heroku/client/*.svg example/heroku/client/*.js && cross-env NODE_ENV=production webpack --config src/example/webpackConfig.coffee --colors --progress -p && cp example/*.eot example/*.ttf example/*.woff* example/*.svg example/*.js example/heroku/client/",
     "buildExampleWatch": "webpack --config src/example/webpackConfig.coffee --colors --progress --watch",
-    "example": "coffee src/example/server.coffee",
+    "example": "npm run compile && node lib/example/server",
     "build": "coffee package.coffee && npm run compile && npm run buildServerLogsApp && npm run buildExtension && npm run test && npm run zipExtension && npm run buildExampleHeroku && npm run xxl && echo 'Remember to update Heroku package.json with the latest SB version!'",
     "travis": "coffee package.coffee && npm run compile && npm run test",
     "test": "npm run testCov",

--- a/src/chromeExtension/components/020-story.cjsx
+++ b/src/chromeExtension/components/020-story.cjsx
@@ -10,6 +10,7 @@ ColoredText       = require './030-coloredText'
 Icon              = require './910-icon'
 actions           = require '../actions/actions'
 ansiColors        = require '../../gral/ansiColors'
+treeLines         = require '../../gral/treeLines'
 k                 = require '../../gral/constants'
 
 _quickFind = (msg, quickFind) ->
@@ -128,9 +129,10 @@ _Story = React.createClass
     out
 
   renderAttachment: (record) -> 
-    {storyId, id} = record
+    {storyId, id, obj, objOptions, version} = record
     props = _.pick @props, ['level', 'timeType', 'setTimeType', 'quickFind', 'seqFullRefresh']
-    return record.obj.map (line, idx) ->
+    lines = if version >= 2 then treeLines(obj, objOptions) else obj
+    return lines.map (line, idx) ->
       <AttachmentLine key={"#{storyId}_#{id}_#{idx}"}
         record={record}
         {...props}

--- a/src/gral/serialize.js
+++ b/src/gral/serialize.js
@@ -1,0 +1,22 @@
+import {
+  isObject,
+  cloneDeep,
+} from '../vendor/lodash';
+
+const CIRCULAR_PLACEHOLDER = '__CIRCULAR__';
+
+const removeCycles = (obj) => {
+  return obj;
+}
+
+const serialize = (obj) => {
+  if (!isObject(obj)) return obj;
+  let out = cloneDeep(obj);
+  out = removeCycles(out);
+  return out;
+}
+
+export {
+  serialize,
+  CIRCULAR_PLACEHOLDER,
+};

--- a/src/gral/serialize.js
+++ b/src/gral/serialize.js
@@ -1,22 +1,28 @@
-import {
-  isObject,
-  cloneDeep,
-} from '../vendor/lodash';
+import { isObject, cloneDeep } from '../vendor/lodash';
 
-const CIRCULAR_PLACEHOLDER = '__CIRCULAR__';
+const CIRCULAR_REF = '[[CIRCULAR]]';
 
-const removeCycles = (obj) => {
+const removeCycles = (obj, stack, visited) => {
+  if (!isObject(obj)) return obj;
+  if (stack.indexOf(obj) >= 0) return CIRCULAR_REF
+  if (visited.indexOf(obj) >= 0) return obj;
+  stack.push(obj);
+  visited.push(obj);
+  Object.keys(obj).forEach(key => {
+    obj[key] = removeCycles(obj[key], stack, visited);
+  });
+  stack.pop();
   return obj;
 }
 
-const serialize = (obj) => {
+const serialize = obj => {
   if (!isObject(obj)) return obj;
   let out = cloneDeep(obj);
-  out = removeCycles(out);
+  out = removeCycles(out, [], []);
   return out;
 }
 
 export {
   serialize,
-  CIRCULAR_PLACEHOLDER,
+  CIRCULAR_REF,
 };

--- a/src/gral/treeLines.coffee
+++ b/src/gral/treeLines.coffee
@@ -1,5 +1,6 @@
 chalk = require 'chalk'
 _ = require '../vendor/lodash'
+{CIRCULAR_REF} = require './serialize'
 
 WRAPPER_KEY = '__wrapper__'
 
@@ -12,7 +13,8 @@ _tree = (node, options, prefix, stack) ->
   for key, val of node
     continue if options.ignoreKeys.indexOf(key) >= 0
     finalPrefix = if key is WRAPPER_KEY then prefix else "#{prefix}#{key}: "
-    if _.isObject(val) and _.includes(stack, val)  # Avoid circular dependencies
+    if (_.isObject(val) and _.includes(stack, val)) or  # Avoid circular dependencies
+       (val is CIRCULAR_REF)
       out.push "#{finalPrefix}#{chalk.green.bold '[CIRCULAR]'}"
     else if _.isArray(val) and val.length is 0
       out.push "#{finalPrefix}#{chalk.bold '[]'}"

--- a/src/listeners/browserExtension.coffee
+++ b/src/listeners/browserExtension.coffee
@@ -1,6 +1,5 @@
 timm        = require 'timm'
 ifExtension = require './interfaceExtension'
-serializeAttachments = require './serializeAttachments'
 ifExtension = require './interfaceExtension'
 filters     = require '../gral/filters'
 k           = require '../gral/constants'
@@ -34,7 +33,7 @@ create = (baseConfig) ->
     init: ->
       ifExtension.rx _extensionRxMsg
     process: (record) -> 
-      ifExtension.tx {type: 'RECORDS', data: [serializeAttachments record]}
+      ifExtension.tx {type: 'RECORDS', data: [record]}
     ## config: (newConfig) -> config = timm.merge config, newConfig
   listener
 

--- a/src/listeners/serializeAttachments.coffee
+++ b/src/listeners/serializeAttachments.coffee
@@ -1,8 +1,0 @@
-timm        = require 'timm'
-treeLines   = require '../gral/treeLines'
-
-module.exports = (record) ->
-  return record if not record.hasOwnProperty 'obj'
-  ### istanbul ignore next ###
-  return record if record.fSerialized
-  return timm.set record, 'obj', treeLines(record.obj, record.objOptions)

--- a/src/listeners/wsClient.coffee
+++ b/src/listeners/wsClient.coffee
@@ -3,7 +3,6 @@ timm        = require 'timm'
 _           = require '../vendor/lodash'
 k           = require '../gral/constants'
 ifExtension = require './interfaceExtension'
-serializeAttachments = require './serializeAttachments'
 
 DEFAULT_CONFIG = 
   uploadClientStories: false
@@ -69,7 +68,6 @@ _uploadPending = ->
 
 _uploadRecord = (record, config) ->
   return if not config.uploadClientStories
-  record = serializeAttachments record
   record = timm.set record, 'uploadedBy', _uploaderId
   if _uploadBuf.length < 2000
     _uploadBuf.push record

--- a/src/listeners/wsServer.coffee
+++ b/src/listeners/wsServer.coffee
@@ -6,7 +6,6 @@ socketio    = require 'socket.io'
 Promise     = require 'bluebird'
 chalk       = require 'chalk'
 timm        = require 'timm'
-serializeAttachments = require './serializeAttachments'
 filters     = require '../gral/filters'
 k           = require '../gral/constants'
 
@@ -155,12 +154,12 @@ _socketBroadcast = ->
 
 # Get the (long) list of buffered records from the hub.
 # Process their `obj` fields so that they don't include circular references
-_getBufferedRecords = (hub) -> hub.getBufferedRecords().map serializeAttachments
+_getBufferedRecords = (hub) -> hub.getBufferedRecords()
 
 # Manage the (short) broadcast buffer (note that `socketBroadcast` is 
 # normally throttled)
 _broadcastBuf = []
-_enqueueRecord = (record, config) -> _broadcastBuf.push serializeAttachments record
+_enqueueRecord = (record, config) -> _broadcastBuf.push record
 
 #-------------------------------------------------
 # ## Main processing function

--- a/src/webpackConfigBase.coffee
+++ b/src/webpackConfigBase.coffee
@@ -1,3 +1,5 @@
+require 'babel-core/register'
+path = require 'path'
 webpack = require 'webpack'
 
 LANGS = ['en_gb']
@@ -23,6 +25,10 @@ module.exports =
     ,
       test: /\.coffee$/
       loader: 'babel!coffee'
+    ,
+      test: /\.js$/
+      exclude: path.resolve(process.cwd(), 'node_modules')
+      loader: 'babel'
     ,
       test: /\.(otf|eot|svg|ttf|woff|woff2)(\?v=[0-9]\.[0-9]\.[0-9])?$/
       loader: 'file'

--- a/test/lib/01-storyboard.coffee
+++ b/test/lib/01-storyboard.coffee
@@ -50,7 +50,7 @@ describe 'storyboard', ->
       expect(_spy).to.have.been.calledOnce
       record = _spy.args[0][0]
       expect(record.msg).to.equal 'msg3'
-      expect(record.obj).to.equal obj
+      expect(record.obj).to.deep.equal obj
 
   describe 'creating a child story', ->
 

--- a/test/lib/05-serialize.coffee
+++ b/test/lib/05-serialize.coffee
@@ -1,7 +1,7 @@
 _ = require 'lodash'
 chalk = require 'chalk'
 {expect} = require './imports'
-{serialize, CIRCULAR_PLACEHOLDER} = require '../../lib/gral/serialize'
+{serialize, CIRCULAR_REF} = require '../../lib/gral/serialize'
 
 describe 'serialize', ->
 
@@ -12,8 +12,10 @@ describe 'serialize', ->
     expect(serialize(undefined)).to.be.undefined
 
   it 'should return the same object for scalars', ->
-    expect(serialize(3)).to.equal(3)
-    expect(serialize('a')).to.equal('a')
+    expect(serialize(3)).to.equal 3
+    expect(serialize('a')).to.equal 'a'
+    expect(serialize(true)).to.equal true
+    expect(serialize(false)).to.equal false
 
   describe 'with objects', ->
     it 'should clone the object', ->
@@ -23,3 +25,23 @@ describe 'serialize', ->
       obj.b.b2 = 5
       expect(obj2.b.b1).to.equal(3)
       expect(obj2.b.b2).to.be.undefined
+
+    it 'should clean the object of circular references (I)', ->
+      obj = {a: 3, b: {b1: 3}}
+      obj.b.b2 = obj
+      obj2 = serialize obj
+      expect(obj2.b.b2).to.equal CIRCULAR_REF
+      expect(obj.b.b2).to.equal obj
+
+    it 'should clean the object of circular references (II)', ->
+      obj = [{a: 1}, {b: 2}]
+      obj[2] = obj
+      obj2 = serialize obj
+      expect(obj2[2]).to.equal CIRCULAR_REF
+
+    it 'should not detect circular references where there are none', ->
+      obj = {a: 3, b: {b1: 3}}
+      obj.c = obj.b
+      obj2 = serialize obj
+      expect(obj2.c.b1).to.equal 3
+      expect(obj2.c).to.equal(obj2.b)

--- a/test/lib/05-serialize.coffee
+++ b/test/lib/05-serialize.coffee
@@ -1,0 +1,25 @@
+_ = require 'lodash'
+chalk = require 'chalk'
+{expect} = require './imports'
+{serialize, CIRCULAR_PLACEHOLDER} = require '../../lib/gral/serialize'
+
+describe.only 'serialize', ->
+
+  it 'should return the same object for null', ->
+    expect(serialize(null)).to.be.null
+
+  it 'should return the same object for undefined', ->
+    expect(serialize(undefined)).to.be.undefined
+
+  it 'should return the same object for scalars', ->
+    expect(serialize(3)).to.equal(3)
+    expect(serialize('a')).to.equal('a')
+
+  describe 'with objects', ->
+    it 'should clone the object', ->
+      obj = {a: 3, b: {b1: 3}}
+      obj2 = serialize obj
+      obj.b.b1 = 2
+      obj.b.b2 = 5
+      expect(obj2.b.b1).to.equal(3)
+      expect(obj2.b.b2).to.be.undefined

--- a/test/lib/05-serialize.coffee
+++ b/test/lib/05-serialize.coffee
@@ -3,7 +3,7 @@ chalk = require 'chalk'
 {expect} = require './imports'
 {serialize, CIRCULAR_PLACEHOLDER} = require '../../lib/gral/serialize'
 
-describe.only 'serialize', ->
+describe 'serialize', ->
 
   it 'should return the same object for null', ->
     expect(serialize(null)).to.be.null

--- a/test/lib/11-wsServerListener.coffee
+++ b/test/lib/11-wsServerListener.coffee
@@ -150,7 +150,7 @@ describe "wsServerListener", ->
           msg = _spy.args[0][0]
           expect(msg.type).to.equal 'RECORDS'
           expect(msg.data).to.have.length 1
-          expect(msg.data[0].obj).to.have.length 2
+          expect(msg.data[0].obj).to.deep.equal {a: 4, b: 3}
 
       it "should report invalid messages", ->
         _socket.emit 'MSG', {type: 'INVALID_MSG_TYPE'}

--- a/test/lib/13-browserExtensionListener.coffee
+++ b/test/lib/13-browserExtensionListener.coffee
@@ -48,12 +48,11 @@ describe "browserExtensionListener", ->
         expect(msg.type).to.equal 'RECORDS'
         expect(msg.data[0].msg).to.contain 'rainbow'
 
-    it "should preprocess attachments through treeLines", ->
+    it "should not preprocess attachments", ->
       _spyClientWinTxMsg.reset()
       mainStory.info "We can be heroes...", attach: just: "for one day"
       h.waitUntil(1000, -> _spyClientWinTxMsg.callCount > 0)
       .then ->
         record = _spyClientWinTxMsg.args[0][0].data[0]
         expect(record.msg).to.contain 'heroes'
-        expect(record.obj[0]).to.contain 'just'
-        expect(record.obj[0]).to.contain 'one day'
+        expect(record.obj).to.deep.equal {just: 'for one day'}


### PR DESCRIPTION
Instead of performing an *ad hoc* serialization inside the wsServer listener, process all attachments at generation time (removing circular refs) and allow socket.io to send them transparently.