### PR TITLE
FIX DeprecationWarning

### DIFF
--- a/src/listeners/file.js
+++ b/src/listeners/file.js
@@ -52,7 +52,7 @@ class FileListener {
     const { fd } = this;
     if (fd == null) return;
     const lines = recordToLines(record, this.config);
-    lines.forEach(({ text }) => fs.write(fd, `${text}\n`, null, 'utf8'));
+    lines.forEach(({ text }) => fs.write(fd, `${text}\n`, () => {}, 'utf8'));
   }
 }
 


### PR DESCRIPTION
FIX DeprecationWarning: Calling an asynchronous function without callback is deprecated.